### PR TITLE
make routes mutually exclusive for COVID-19

### DIFF
--- a/SLATE_US_UUTAH_LONEPEAK/lonepeak-slate-values.yaml
+++ b/SLATE_US_UUTAH_LONEPEAK/lonepeak-slate-values.yaml
@@ -61,6 +61,7 @@ HTCondorCeConfig: |+
     GridResource = "batch slurm osguserl@lonepeak1.chpc.utah.edu";
     Requirements = (Owner == "osguserl");
     set_default_queue = "lonepeak-osg";
+    Requirements = (TARGET.IsCOVID19 =!= true);
     # 16 GB
     set_default_maxMemory = 16384;
     # 72 hours


### PR DESCRIPTION
We want to make sure that if a job is COVID-19 that it will take the job route to dedicated resources. We are trying to add this requirement to the default route so that COVID jobs cannot take the opportunistic route.